### PR TITLE
Update Developer Rig setup download links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The recommended path for building this sample is with the Twitch Developer Rig. 
 
 ## Setup
 
-1. Download the Developer Rig for [Mac](https://s3-us-west-2.amazonaws.com/developer-rig-install-update-development/Twitch+Developer+Rig-0.9.3.dmg) or [Windows](https://s3-us-west-2.amazonaws.com/developer-rig-install-update-development/Twitch+Developer+Rig+Setup+0.9.3.exe), then open the downloaded file to install the Rig. Linux will be available soon.
+1. Download the Developer Rig for [Mac](https://link.twitch.tv/2u8BNNm) or [Windows](https://link.twitch.tv/2JcsuGQ), then open the downloaded file to install the Rig. Linux will be available soon.
 2. Visit the Extensions section of you [Developer Dashabord](https://dev.twitch.tv/dashboard/extensions). You will need to have a Twitch account to login and two factor authentication (2FA) will need to be activated. You will see a button prompting you with instructions if 2FA has not yet been activated.
 3. Click the "Create Extension" button on this page and you will be taken to a form to setup your new Extension.
 4. Make sure you select "Video - Component" under the "Type Of Extension" section, check the box to indicate that you are using the Developer Rig, and fill out the remaining fields.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The recommended path for building this sample is with the Twitch Developer Rig. 
 
 ## Setup
 
-1. Download the Developer Rig for [Mac](https://link.twitch.tv/2u8BNNm) or [Windows](https://link.twitch.tv/2JcsuGQ), then open the downloaded file to install the Rig. Linux will be available soon.
+1. Download the Developer Rig for [Mac](https://link.twitch.tv/2u8BNNm), [Windows](https://link.twitch.tv/2JcsuGQ), or [Linux](https://link.twitch.tv/2F8hFjw). Then, open the downloaded file to install the Rig.
 2. Visit the Extensions section of you [Developer Dashabord](https://dev.twitch.tv/dashboard/extensions). You will need to have a Twitch account to login and two factor authentication (2FA) will need to be activated. You will see a button prompting you with instructions if 2FA has not yet been activated.
 3. Click the "Create Extension" button on this page and you will be taken to a form to setup your new Extension.
 4. Make sure you select "Video - Component" under the "Type Of Extension" section, check the box to indicate that you are using the Developer Rig, and fill out the remaining fields.


### PR DESCRIPTION
#2 seems to have been reverted when #1 was improperly merged with https://github.com/twitchdev/extension-getting-started/commit/84f1455866b6cb8bb14ebcc8c3d70e408dd9e87c, so currently, the README is still using the Developer Rig 0.9.3 setup download links instead of 0.9.8.

Regardless, this PR updates the README to use the shortened link.twitch.tv redirect links, now used [in the Twitch Developers documentation for the Developer Rig](https://dev.twitch.tv/docs/extensions/rig/#starting-up-the-rig) and [added to the Developer Rig repository README](https://github.com/twitchdev/developer-rig/commit/2917fc2ef84a68dc7f22bd1bc6ceea3749e3196b). This PR also adds the corresponding link for Linux.

Currently, these link.twitch.tv links redirect to the Developer Rig 1.0.0 setups for each platform:
- https://link.twitch.tv/2u8BNNm (Mac) -> https://s3-us-west-2.amazonaws.com/developer-rig-install-update-development/Twitch+Developer+Rig-1.0.0.dmg
- https://link.twitch.tv/2JcsuGQ (Windows) -> https://s3-us-west-2.amazonaws.com/developer-rig-install-update-development/Twitch+Developer+Rig+Setup+1.0.0.exe
- https://link.twitch.tv/2F8hFjw (Linux) -> https://s3-us-west-2.amazonaws.com/developer-rig-install-update-development/developer-rig-1.0.0-x86_64.AppImage